### PR TITLE
fix: detect squash merges via GitHub API

### DIFF
--- a/.github/workflows/protect-master-reusable.yml
+++ b/.github/workflows/protect-master-reusable.yml
@@ -17,22 +17,40 @@ jobs:
     if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', inputs.protected-branch)
     steps:
       - name: Check if push is from PR merge
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           COMMIT_MSG="${{ github.event.head_commit.message }}"
           FIRST_LINE=$(echo "$COMMIT_MSG" | head -n 1)
+          COMMIT_SHA="${{ github.sha }}"
 
           echo "🔍 Checking push to ${{ inputs.protected-branch }}..."
+          echo "Commit SHA: $COMMIT_SHA"
           echo "Commit message: $FIRST_LINE"
           echo ""
 
-          # Pattern to detect PR merge commits
+          # Method 1: Check commit message patterns
           # Example: "feat: add feature (#123)" or "Merge pull request #123"
           PR_NUMBER_PATTERN='\(#[0-9]+\)$'
           MERGE_PATTERN='^Merge pull request'
 
           if [[ "$FIRST_LINE" =~ $PR_NUMBER_PATTERN ]] || [[ "$FIRST_LINE" =~ $MERGE_PATTERN ]]; then
-            echo "✅ PR merge detected - allowing push"
+            echo "✅ PR merge detected via commit message pattern"
             echo "This commit was created through a pull request merge"
+            exit 0
+          fi
+
+          # Method 2: Check GitHub API for PR association
+          # This handles squash merges that don't include (#PR) in message
+          echo "Checking GitHub API for PR association..."
+          PR_COUNT=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" \
+            --jq 'length' 2>/dev/null || echo "0")
+
+          if [[ "$PR_COUNT" -gt 0 ]]; then
+            PR_NUMBERS=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" \
+              --jq '.[].number' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+            echo "✅ PR merge detected via GitHub API"
+            echo "This commit is associated with PR(s): #$PR_NUMBERS"
             exit 0
           fi
 


### PR DESCRIPTION
## Problem

Protect-master workflow fails on legitimate PR merges when using GitHub's squash merge feature without PR number in commit message.

**Current behavior:**
- PR #50 in dotfiles was squashed and merged
- Commit message: feat: add installation testing CI workflow (no PR number)
- protect-master workflow failed with Direct pushes not allowed
- This is a false positive - commit WAS from PR merge

**Root cause:**
GitHub squash merge doesn't automatically append PR number unless explicitly included in squash message. Workflow only checks commit message patterns, missing squash merges.

## Solution

Add GitHub API check as fallback detection method.

**Method 1 (existing):** Check commit message patterns
- feat: message (#123) - PR number in message
- Merge pull request #123 - Traditional merge

**Method 2 (new):** Query GitHub API
- Check if commit SHA is associated with any PR
- Handles squash merges without PR number
- More robust and future-proof

## Changes

- Add GH_TOKEN environment variable
- Query GitHub API: /repos/{owner}/{repo}/commits/{sha}/pulls
- Fall back to API check if message patterns don't match
- Display PR numbers when detected via API

## Testing

Will validate with current failing commit bcd11da from dotfiles master.

## Impact

- Fixes false positive failures on master
- No behavior change for direct pushes (still blocked)
- Handles all GitHub merge methods correctly

Fixes false positive in maxrantil/dotfiles after PR #50 merge.